### PR TITLE
2.2.0

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,2 +1,0 @@
-exclude_paths:
-- ext/*

--- a/.editorconfig
+++ b/.editorconfig
@@ -13,3 +13,4 @@ trim_trailing_whitespace = false
 
 [*.{c,h}]
 indent_size = 8
+indent_style = tab

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,13 @@ before_script:
   - if [ "$BIJECTIVE_EXT" == "yes" ]; then sh -c "cd ext/bijective && phpize && ./configure && make && sudo make install"; fi
   - if [ "$BIJECTIVE_EXT" == "yes" ]; then echo "extension=bijective.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`; fi
 
-
 script:
   - cd ext/bijective
   - if [ "$BIJECTIVE_EXT" == "yes" ]; then yes n | make test | tee output ; grep -E 'Tests failed +. +0' output; fi
   - cd ../..
   - phpunit
+
+notifications:
+  email:
+    recipients:
+      - daniel@honestempire.com

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Bijective
 
 [![Build Status](https://secure.travis-ci.org/honestempire/bijective.svg?branch=master)](http://travis-ci.org/honestempire/bijective)
-[![Code Climate](https://codeclimate.com/github/honestempire/bijective.svg)](https://codeclimate.com/github/honestempire/bijective)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/honestempire/bijective/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/honestempire/bijective/?branch=master)
 
 Bijective is a library that can compute pairings between alphanumeric strings,

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
             "role": "Programmer"
         }
     ],
-    "version": "2.1.0",
+    "version": "2.2.0",
     "require": {
         "php": ">=7.0"
     },

--- a/ext/bijective/bijective.c
+++ b/ext/bijective/bijective.c
@@ -89,6 +89,10 @@ zend_module_entry bijective_module_entry = {
 };
 /* }}} */
 
+#ifdef COMPILE_DL_BIJECTIVE
+ZEND_GET_MODULE(bijective)
+#endif
+
 /* {{{ PHP_MINIT_FUNCTION
  */
 PHP_MINIT_FUNCTION(bijective)

--- a/ext/bijective/bijective.c
+++ b/ext/bijective/bijective.c
@@ -126,15 +126,9 @@ PHP_FUNCTION(bijective_encode)
 {
         zend_long input;
 
-#ifndef FAST_ZPP
-        if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "l", &input) == FAILURE) {
-                return;
-        }
-#else
         ZEND_PARSE_PARAMETERS_START(1, 1)
                 Z_PARAM_LONG(input)
         ZEND_PARSE_PARAMETERS_END();
-#endif
 
         smart_string encoded = {};
         uint8_t modulus;
@@ -158,15 +152,9 @@ PHP_FUNCTION(bijective_decode)
 {
         zend_string *input;
 
-#ifndef FAST_ZPP
-        if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "S", &input) == FAILURE) {
-                return;
-        }
-#else
         ZEND_PARSE_PARAMETERS_START(1, 1)
                 Z_PARAM_STR(input)
         ZEND_PARSE_PARAMETERS_END();
-#endif
 
         zend_long decoded = 0;
         size_t len = ZSTR_LEN(input), i, pos;
@@ -186,14 +174,8 @@ PHP_FUNCTION(bijective_decode)
  * Returns a string representation of a regular expression for recognising encoded strings. */
 PHP_FUNCTION(bijective_expression)
 {
-#ifndef FAST_ZPP
-        if (zend_parse_parameters_none() == FAILURE) {
-                return;
-        }
-#else
         ZEND_PARSE_PARAMETERS_START(0, 0)
         ZEND_PARSE_PARAMETERS_END();
-#endif
 
         RETURN_STRING("/^[a-z0-9]+$/i");
 }

--- a/ext/bijective/bijective.c
+++ b/ext/bijective/bijective.c
@@ -40,7 +40,7 @@ void bijective_reverse(char *s)
 {
         char *r = s;
 
-        while (r && *r) {
+        while (*r) {
                 ++r;
         }
 

--- a/ext/bijective/bijective.c
+++ b/ext/bijective/bijective.c
@@ -32,31 +32,31 @@
 #include "ext/standard/php_smart_string.h"
 
 static const char elements[] =
-        "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+	"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
 
 #define BIJECTIVE_ELEMENTS_COUNT 62
 
 void bijective_reverse(char *s)
 {
-        char *r = s;
+	char *r = s;
 
-        while (*r) {
-                ++r;
-        }
+	while (*r) {
+        	++r;
+	}
 
-        for (--r; s < r; ++s, --r) {
-                *s = *s ^ *r;
-                *r = *s ^ *r;
-                *s = *s ^ *r;
-        }
+	for (--r; s < r; ++s, --r) {
+		*s = *s ^ *r;
+		*r = *s ^ *r;
+		*s = *s ^ *r;
+	}
 }
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_bijective_encode, 0, 0, 1)
-        ZEND_ARG_INFO(0, input)
+	ZEND_ARG_INFO(0, input)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_bijective_decode, 0, 0, 1)
-        ZEND_ARG_INFO(0, input)
+	ZEND_ARG_INFO(0, input)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO(arginfo_bijective_expression, 0)
@@ -66,38 +66,34 @@ ZEND_END_ARG_INFO()
  * Each function must have an entry in bijective_functions[].
  */
 static const zend_function_entry bijective_functions[] = {
-        PHP_FE(bijective_encode,     arginfo_bijective_encode)
-        PHP_FE(bijective_decode,     arginfo_bijective_decode)
-        PHP_FE(bijective_expression, arginfo_bijective_expression)
-        PHP_FE_END
+	PHP_FE(bijective_encode,     arginfo_bijective_encode)
+	PHP_FE(bijective_decode,     arginfo_bijective_decode)
+	PHP_FE(bijective_expression, arginfo_bijective_expression)
+	PHP_FE_END
 };
 /* }}} */
 
 /* {{{ bijective_module_entry
  */
 zend_module_entry bijective_module_entry = {
-        STANDARD_MODULE_HEADER,
-        "bijective",
-        bijective_functions,
-        PHP_MINIT(bijective),
-        PHP_MSHUTDOWN(bijective),
-        NULL,
-        NULL,
-        PHP_MINFO(bijective),
-        BIJECTIVE_VERSION,
-        STANDARD_MODULE_PROPERTIES
+	STANDARD_MODULE_HEADER,
+	"bijective",
+	bijective_functions,
+	PHP_MINIT(bijective),
+	PHP_MSHUTDOWN(bijective),
+	NULL,
+	NULL,
+	PHP_MINFO(bijective),
+	BIJECTIVE_VERSION,
+	STANDARD_MODULE_PROPERTIES
 };
 /* }}} */
-
-#ifdef COMPILE_DL_BIJECTIVE
-ZEND_GET_MODULE(bijective)
-#endif
 
 /* {{{ PHP_MINIT_FUNCTION
  */
 PHP_MINIT_FUNCTION(bijective)
 {
-        return SUCCESS;
+	return SUCCESS;
 }
 /* }}} */
 
@@ -105,7 +101,7 @@ PHP_MINIT_FUNCTION(bijective)
  */
 PHP_MSHUTDOWN_FUNCTION(bijective)
 {
-        return SUCCESS;
+	return SUCCESS;
 }
 /* }}} */
 
@@ -113,10 +109,10 @@ PHP_MSHUTDOWN_FUNCTION(bijective)
  */
 PHP_MINFO_FUNCTION(bijective)
 {
-        php_info_print_table_start();
-        php_info_print_table_header(2, "Bijective functions", "enabled");
-        php_info_print_table_row(2, "Version", BIJECTIVE_VERSION);
-        php_info_print_table_end();
+	php_info_print_table_start();
+	php_info_print_table_header(2, "Bijective functions", "enabled");
+	php_info_print_table_row(2, "Version", BIJECTIVE_VERSION);
+	php_info_print_table_end();
 }
 /* }}} */
 
@@ -124,25 +120,25 @@ PHP_MINFO_FUNCTION(bijective)
  * Encodes an integer into a corresponding string. */
 PHP_FUNCTION(bijective_encode)
 {
-        zend_long input;
+	zend_long input;
 
-        ZEND_PARSE_PARAMETERS_START(1, 1)
-                Z_PARAM_LONG(input)
-        ZEND_PARSE_PARAMETERS_END();
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_LONG(input)
+	ZEND_PARSE_PARAMETERS_END();
 
-        smart_string encoded = {};
-        uint8_t modulus;
+	smart_string encoded = {};
+	uint8_t modulus;
 
-        do {
-                modulus = input % BIJECTIVE_ELEMENTS_COUNT;
-                smart_string_appendc(&encoded, elements[modulus]);
-                input = (input - modulus) / BIJECTIVE_ELEMENTS_COUNT;
-        } while (input > 0);
+	do {
+		modulus = input % BIJECTIVE_ELEMENTS_COUNT;
+		smart_string_appendc(&encoded, elements[modulus]);
+		input = (input - modulus) / BIJECTIVE_ELEMENTS_COUNT;
+	} while (input > 0);
 
-        smart_string_0(&encoded);
-        bijective_reverse(encoded.c);
-        RETVAL_STRING(encoded.c);
-        smart_string_free(&encoded);
+	smart_string_0(&encoded);
+	bijective_reverse(encoded.c);
+	RETVAL_STRING(encoded.c);
+	smart_string_free(&encoded);
 }
 /* }}} */
 
@@ -150,23 +146,23 @@ PHP_FUNCTION(bijective_encode)
  * Decodes a string into a corresponding integer. */
 PHP_FUNCTION(bijective_decode)
 {
-        zend_string *input;
+	zend_string *input;
 
-        ZEND_PARSE_PARAMETERS_START(1, 1)
-                Z_PARAM_STR(input)
-        ZEND_PARSE_PARAMETERS_END();
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_STR(input)
+	ZEND_PARSE_PARAMETERS_END();
 
-        zend_long decoded = 0;
-        size_t len = ZSTR_LEN(input), i, pos;
-        char *chr;
+	zend_long decoded = 0;
+	size_t len = ZSTR_LEN(input), i, pos;
+	char *chr;
 
-        for (i = len; i--;) {
-                chr = strchr(elements, ZSTR_VAL(input)[i]);
-                pos = (int) (chr - elements);
-                decoded = pos * (int) pow((double) BIJECTIVE_ELEMENTS_COUNT, len - i - 1) + decoded;
-        }
+	for (i = len; i--;) {
+		chr = strchr(elements, ZSTR_VAL(input)[i]);
+		pos = (int) (chr - elements);
+		decoded = pos * (int) pow((double) BIJECTIVE_ELEMENTS_COUNT, len - i - 1) + decoded;
+	}
 
-        RETURN_LONG(decoded);
+	RETURN_LONG(decoded);
 }
 /* }}} */
 
@@ -174,9 +170,9 @@ PHP_FUNCTION(bijective_decode)
  * Returns a string representation of a regular expression for recognising encoded strings. */
 PHP_FUNCTION(bijective_expression)
 {
-        ZEND_PARSE_PARAMETERS_START(0, 0)
-        ZEND_PARSE_PARAMETERS_END();
+	ZEND_PARSE_PARAMETERS_START(0, 0)
+	ZEND_PARSE_PARAMETERS_END();
 
-        RETURN_STRING("/^[a-z0-9]+$/i");
+	RETURN_STRING("/^[a-z0-9]+$/i");
 }
 /* }}} */

--- a/ext/bijective/config.w32
+++ b/ext/bijective/config.w32
@@ -1,0 +1,8 @@
+dnl $Id$
+dnl config.w32 for extension bijective
+
+ARG_ENABLE("bijective");
+
+if test "$PHP_BIJECTIVE" != "no"; then
+  PHP_NEW_EXTENSION(bijective, bijective.c, $ext_shared)
+fi

--- a/ext/bijective/php_bijective.h
+++ b/ext/bijective/php_bijective.h
@@ -27,7 +27,6 @@
 extern zend_module_entry bijective_module_entry;
 #define phpext_bijective_ptr &bijective_module_entry;
 
-#define BIJECTIVE_NS "Honest\Bijective"
 #define BIJECTIVE_VERSION "2.2.0"
 
 #ifdef ZTS

--- a/ext/bijective/php_bijective.h
+++ b/ext/bijective/php_bijective.h
@@ -28,7 +28,7 @@ extern zend_module_entry bijective_module_entry;
 #define phpext_bijective_ptr &bijective_module_entry;
 
 #define BIJECTIVE_NS "Honest\Bijective"
-#define BIJECTIVE_VERSION "2.1.0"
+#define BIJECTIVE_VERSION "2.2.0"
 
 #ifdef ZTS
 #include "TSRM.h"


### PR DESCRIPTION
- Start adding support for Windows [incomplete]
- Use `FAST_ZPP` only – compatibility with PHP 7.1+ for the extension only
- Coding standards changed for the extension
- Removed unused namespace constant in the extension
